### PR TITLE
fix: always order by apiVersion, kind, metadata, spec

### DIFF
--- a/packages/cli/src/generateCore.ts
+++ b/packages/cli/src/generateCore.ts
@@ -194,10 +194,21 @@ function morph() {
                         ],
                     };
 
+                    const preferredOrder = ['apiVersion', 'kind', 'metadata', 'spec'];
+                    const orderedProps = classDeclaration.getProperties().sort((a, b) => {
+                        const aIndex = preferredOrder.indexOf(a.getName());
+                        const bIndex = preferredOrder.indexOf(b.getName());
+                        if (aIndex === -1 && bIndex === -1) return 0;
+                        if (aIndex === -1) return 1;
+                        if (bIndex === -1) return -1;
+                        return aIndex - bIndex;
+                    });
+
                     c.statements = new Array<StatementStructures>();
                     c.statements.push('super(args.metadata?.name || name);');
-                    for (const prop of classDeclaration.getProperties()) {
+                    for (const [i, prop] of orderedProps.entries()) {
                         prop.setIsReadonly(true);
+                        classDeclaration.getProperty(prop.getName())?.setOrder(i);
                         const interfaceProp: PropertySignatureStructure = {
                             kind: StructureKind.PropertySignature,
                             name: prop.getName(),

--- a/packages/core/src/models/CSIStorageCapacityv1.ts
+++ b/packages/core/src/models/CSIStorageCapacityv1.ts
@@ -3,9 +3,9 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface CSIStorageCapacityv1Args {
+  readonly metadata?: NamespacedObjectMetav1;
   readonly capacity?: number | string;
   readonly maximumVolumeSize?: number | string;
-  readonly metadata?: NamespacedObjectMetav1;
   readonly nodeTopology?: LabelSelectorv1;
   readonly storageClassName: string;
 }
@@ -19,21 +19,21 @@ export class CSIStorageCapacityv1 extends NamespacedApiObject {
    */
   readonly apiVersion = 'storage.k8s.io/v1';
   /**
-   * capacity is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.  The semantic is currently (CSI spec 1.2) defined as: The available capacity, in bytes, of the storage that can be used to provision volumes. If not set, that information is currently unavailable.
-   */
-  readonly capacity?: number | string;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'CSIStorageCapacity';
   /**
-   * maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.  This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
-   */
-  readonly maximumVolumeSize?: number | string;
-  /**
    * Standard object\'s metadata. The name has no particular meaning. It must be a DNS subdomain (dots allowed, 253 characters). To ensure that there are no conflicts with other CSI drivers on the cluster, the recommendation is to use csisc-<uuid>, a generated name, or a reverse-domain name which ends with the unique CSI driver name.  Objects are namespaced.  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
    */
   readonly metadata: NamespacedObjectMetav1;
+  /**
+   * capacity is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.  The semantic is currently (CSI spec 1.2) defined as: The available capacity, in bytes, of the storage that can be used to provision volumes. If not set, that information is currently unavailable.
+   */
+  readonly capacity?: number | string;
+  /**
+   * maximumVolumeSize is the value reported by the CSI driver in its GetCapacityResponse for a GetCapacityRequest with topology and parameters that match the previous fields.  This is defined since CSI spec 1.4.0 as the largest size that may be used in a CreateVolumeRequest.capacity_range.required_bytes field to create a volume with the same parameters as those in GetCapacityRequest. The corresponding value in the Kubernetes API is ResourceRequirements.Requests in a volume claim.
+   */
+  readonly maximumVolumeSize?: number | string;
   /**
    * nodeTopology defines which nodes have access to the storage for which capacity was reported. If not set, the storage is not accessible from any node in the cluster. If empty, the storage is accessible from all nodes. This field is immutable.
    */
@@ -45,10 +45,10 @@ export class CSIStorageCapacityv1 extends NamespacedApiObject {
 
   constructor(app: K8sApp, name: string, args: CSIStorageCapacityv1Args) {
     super(args.metadata?.name || name);
-    this.capacity = args.capacity;
-    this.maximumVolumeSize = args.maximumVolumeSize;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.capacity = args.capacity;
+    this.maximumVolumeSize = args.maximumVolumeSize;
     this.nodeTopology = args.nodeTopology;
     this.storageClassName = args.storageClassName;
     app.addResource(this);

--- a/packages/core/src/models/ClusterRolev1.ts
+++ b/packages/core/src/models/ClusterRolev1.ts
@@ -5,8 +5,8 @@ import { K8sApp } from '../K8sApp.js';
 import { ApiObject } from '../ApiObject.js';
 
 export interface ClusterRolev1Args {
-  readonly aggregationRule?: AggregationRulev1;
   readonly metadata?: ObjectMetav1;
+  readonly aggregationRule?: AggregationRulev1;
   readonly rules?: Array<PolicyRulev1>;
 }
 
@@ -14,10 +14,6 @@ export interface ClusterRolev1Args {
  * ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
  */
 export class ClusterRolev1 extends ApiObject {
-  /**
-   * AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
-   */
-  readonly aggregationRule?: AggregationRulev1;
   /**
    * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
    */
@@ -31,15 +27,19 @@ export class ClusterRolev1 extends ApiObject {
    */
   readonly metadata: ObjectMetav1;
   /**
+   * AggregationRule is an optional field that describes how to build the Rules for this ClusterRole. If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be stomped by the controller.
+   */
+  readonly aggregationRule?: AggregationRulev1;
+  /**
    * Rules holds all the PolicyRules for this ClusterRole
    */
   readonly rules?: Array<PolicyRulev1>;
 
   constructor(app: K8sApp, name: string, args: ClusterRolev1Args) {
     super(args.metadata?.name || name);
-    this.aggregationRule = args.aggregationRule;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.aggregationRule = args.aggregationRule;
     this.rules = args.rules;
     app.addResource(this);
   }

--- a/packages/core/src/models/ConfigMapv1.ts
+++ b/packages/core/src/models/ConfigMapv1.ts
@@ -2,10 +2,10 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface ConfigMapv1Args {
+  readonly metadata?: NamespacedObjectMetav1;
   readonly binaryData?: { [key: string]: string };
   readonly data?: { [key: string]: string };
   readonly immutable?: boolean;
-  readonly metadata?: NamespacedObjectMetav1;
 }
 
 /**
@@ -16,6 +16,14 @@ export class ConfigMapv1 extends NamespacedApiObject {
    * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
    */
   readonly apiVersion = 'v1';
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  readonly kind = 'ConfigMap';
+  /**
+   * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+   */
+  readonly metadata: NamespacedObjectMetav1;
   /**
    * BinaryData contains the binary data. Each key must consist of alphanumeric characters, \'-\', \'_\' or \'.\'. BinaryData can contain byte sequences that are not in the UTF-8 range. The keys stored in BinaryData must not overlap with the ones in the Data field, this is enforced during validation process. Using this field will require 1.10+ apiserver and kubelet.
    */
@@ -28,22 +36,14 @@ export class ConfigMapv1 extends NamespacedApiObject {
    * Immutable, if set to true, ensures that data stored in the ConfigMap cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
    */
   readonly immutable?: boolean;
-  /**
-   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-   */
-  readonly kind = 'ConfigMap';
-  /**
-   * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   */
-  readonly metadata: NamespacedObjectMetav1;
 
   constructor(app: K8sApp, name: string, args: ConfigMapv1Args) {
     super(args.metadata?.name || name);
+    this.metadata = args.metadata || { name };
+    this.metadata.name ??= name;
     this.binaryData = args.binaryData;
     this.data = args.data;
     this.immutable = args.immutable;
-    this.metadata = args.metadata || { name };
-    this.metadata.name ??= name;
     app.addResource(this);
   }
 }

--- a/packages/core/src/models/ControllerRevisionv1.ts
+++ b/packages/core/src/models/ControllerRevisionv1.ts
@@ -2,8 +2,8 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface ControllerRevisionv1Args {
-  readonly data?: any;
   readonly metadata?: NamespacedObjectMetav1;
+  readonly data?: any;
   readonly revision: number;
 }
 
@@ -16,10 +16,6 @@ export class ControllerRevisionv1 extends NamespacedApiObject {
    */
   readonly apiVersion = 'apps/v1';
   /**
-   * Data is the serialized representation of the state.
-   */
-  readonly data?: any;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'ControllerRevision';
@@ -28,15 +24,19 @@ export class ControllerRevisionv1 extends NamespacedApiObject {
    */
   readonly metadata: NamespacedObjectMetav1;
   /**
+   * Data is the serialized representation of the state.
+   */
+  readonly data?: any;
+  /**
    * Revision indicates the revision of the state represented by Data.
    */
   readonly revision: number;
 
   constructor(app: K8sApp, name: string, args: ControllerRevisionv1Args) {
     super(args.metadata?.name || name);
-    this.data = args.data;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.data = args.data;
     this.revision = args.revision;
     app.addResource(this);
   }

--- a/packages/core/src/models/CoreEventv1.ts
+++ b/packages/core/src/models/CoreEventv1.ts
@@ -5,6 +5,7 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface CoreEventv1Args {
+  readonly metadata?: NamespacedObjectMetav1;
   readonly action?: string;
   readonly count?: number;
   readonly eventTime?: Date;
@@ -12,7 +13,6 @@ export interface CoreEventv1Args {
   readonly involvedObject: ObjectReferencev1;
   readonly lastTimestamp?: Date;
   readonly message?: string;
-  readonly metadata?: NamespacedObjectMetav1;
   readonly reason?: string;
   readonly related?: ObjectReferencev1;
   readonly reportingComponent?: string;
@@ -27,13 +27,21 @@ export interface CoreEventv1Args {
  */
 export class CoreEventv1 extends NamespacedApiObject {
   /**
-   * What action was taken/failed regarding to the Regarding object.
-   */
-  readonly action?: string;
-  /**
    * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
    */
   readonly apiVersion = 'v1';
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  readonly kind = 'Event';
+  /**
+   * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+   */
+  readonly metadata: NamespacedObjectMetav1;
+  /**
+   * What action was taken/failed regarding to the Regarding object.
+   */
+  readonly action?: string;
   /**
    * The number of times this event has occurred.
    */
@@ -51,10 +59,6 @@ export class CoreEventv1 extends NamespacedApiObject {
    */
   readonly involvedObject: ObjectReferencev1;
   /**
-   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-   */
-  readonly kind = 'Event';
-  /**
    * The time at which the most recent occurrence of this event was recorded.
    */
   readonly lastTimestamp?: Date;
@@ -62,10 +66,6 @@ export class CoreEventv1 extends NamespacedApiObject {
    * A human-readable description of the status of this operation.
    */
   readonly message?: string;
-  /**
-   * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   */
-  readonly metadata: NamespacedObjectMetav1;
   /**
    * This should be a short, machine understandable string that gives the reason for the transition into the object\'s current status.
    */
@@ -97,6 +97,8 @@ export class CoreEventv1 extends NamespacedApiObject {
 
   constructor(app: K8sApp, name: string, args: CoreEventv1Args) {
     super(args.metadata?.name || name);
+    this.metadata = args.metadata || { name };
+    this.metadata.name ??= name;
     this.action = args.action;
     this.count = args.count;
     this.eventTime = args.eventTime;
@@ -104,8 +106,6 @@ export class CoreEventv1 extends NamespacedApiObject {
     this.involvedObject = args.involvedObject;
     this.lastTimestamp = args.lastTimestamp;
     this.message = args.message;
-    this.metadata = args.metadata || { name };
-    this.metadata.name ??= name;
     this.reason = args.reason;
     this.related = args.related;
     this.reportingComponent = args.reportingComponent;

--- a/packages/core/src/models/EndpointSlicev1.ts
+++ b/packages/core/src/models/EndpointSlicev1.ts
@@ -4,9 +4,9 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface EndpointSlicev1Args {
+  readonly metadata?: NamespacedObjectMetav1;
   readonly addressType: string;
   readonly endpoints: Array<Endpointv1>;
-  readonly metadata?: NamespacedObjectMetav1;
   readonly ports?: Array<DiscoveryEndpointPortv1>;
 }
 
@@ -15,17 +15,9 @@ export interface EndpointSlicev1Args {
  */
 export class EndpointSlicev1 extends NamespacedApiObject {
   /**
-   * addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
-   */
-  readonly addressType: string;
-  /**
    * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
    */
   readonly apiVersion = 'discovery.k8s.io/v1';
-  /**
-   * endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
-   */
-  readonly endpoints: Array<Endpointv1>;
   /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
@@ -35,16 +27,24 @@ export class EndpointSlicev1 extends NamespacedApiObject {
    */
   readonly metadata: NamespacedObjectMetav1;
   /**
+   * addressType specifies the type of address carried by this EndpointSlice. All addresses in this slice must be the same type. This field is immutable after creation. The following address types are currently supported: * IPv4: Represents an IPv4 Address. * IPv6: Represents an IPv6 Address. * FQDN: Represents a Fully Qualified Domain Name.
+   */
+  readonly addressType: string;
+  /**
+   * endpoints is a list of unique endpoints in this slice. Each slice may include a maximum of 1000 endpoints.
+   */
+  readonly endpoints: Array<Endpointv1>;
+  /**
    * ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.
    */
   readonly ports?: Array<DiscoveryEndpointPortv1>;
 
   constructor(app: K8sApp, name: string, args: EndpointSlicev1Args) {
     super(args.metadata?.name || name);
-    this.addressType = args.addressType;
-    this.endpoints = args.endpoints;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.addressType = args.addressType;
+    this.endpoints = args.endpoints;
     this.ports = args.ports;
     app.addResource(this);
   }

--- a/packages/core/src/models/EventsEventv1.ts
+++ b/packages/core/src/models/EventsEventv1.ts
@@ -5,13 +5,13 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface EventsEventv1Args {
+  readonly metadata?: NamespacedObjectMetav1;
   readonly action?: string;
   readonly deprecatedCount?: number;
   readonly deprecatedFirstTimestamp?: Date;
   readonly deprecatedLastTimestamp?: Date;
   readonly deprecatedSource?: EventSourcev1;
   readonly eventTime: Date;
-  readonly metadata?: NamespacedObjectMetav1;
   readonly note?: string;
   readonly reason?: string;
   readonly regarding?: ObjectReferencev1;
@@ -27,13 +27,21 @@ export interface EventsEventv1Args {
  */
 export class EventsEventv1 extends NamespacedApiObject {
   /**
-   * action is what action was taken/failed regarding to the regarding object. It is machine-readable. This field cannot be empty for new Events and it can have at most 128 characters.
-   */
-  readonly action?: string;
-  /**
    * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
    */
   readonly apiVersion = 'events.k8s.io/v1';
+  /**
+   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+   */
+  readonly kind = 'Event';
+  /**
+   * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+   */
+  readonly metadata: NamespacedObjectMetav1;
+  /**
+   * action is what action was taken/failed regarding to the regarding object. It is machine-readable. This field cannot be empty for new Events and it can have at most 128 characters.
+   */
+  readonly action?: string;
   /**
    * deprecatedCount is the deprecated field assuring backward compatibility with core.v1 Event type.
    */
@@ -54,14 +62,6 @@ export class EventsEventv1 extends NamespacedApiObject {
    * eventTime is the time when this Event was first observed. It is required.
    */
   readonly eventTime: Date;
-  /**
-   * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-   */
-  readonly kind = 'Event';
-  /**
-   * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-   */
-  readonly metadata: NamespacedObjectMetav1;
   /**
    * note is a human-readable description of the status of this operation. Maximal length of the note is 1kB, but libraries should be prepared to handle values up to 64kB.
    */
@@ -97,14 +97,14 @@ export class EventsEventv1 extends NamespacedApiObject {
 
   constructor(app: K8sApp, name: string, args: EventsEventv1Args) {
     super(args.metadata?.name || name);
+    this.metadata = args.metadata || { name };
+    this.metadata.name ??= name;
     this.action = args.action;
     this.deprecatedCount = args.deprecatedCount;
     this.deprecatedFirstTimestamp = args.deprecatedFirstTimestamp;
     this.deprecatedLastTimestamp = args.deprecatedLastTimestamp;
     this.deprecatedSource = args.deprecatedSource;
     this.eventTime = args.eventTime;
-    this.metadata = args.metadata || { name };
-    this.metadata.name ??= name;
     this.note = args.note;
     this.reason = args.reason;
     this.regarding = args.regarding;

--- a/packages/core/src/models/Evictionv1.ts
+++ b/packages/core/src/models/Evictionv1.ts
@@ -3,8 +3,8 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface Evictionv1Args {
-  readonly deleteOptions?: DeleteOptionsv1;
   readonly metadata?: NamespacedObjectMetav1;
+  readonly deleteOptions?: DeleteOptionsv1;
 }
 
 /**
@@ -16,10 +16,6 @@ export class Evictionv1 extends NamespacedApiObject {
    */
   readonly apiVersion = 'policy/v1';
   /**
-   * DeleteOptions may be provided
-   */
-  readonly deleteOptions?: DeleteOptionsv1;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'Eviction';
@@ -27,12 +23,16 @@ export class Evictionv1 extends NamespacedApiObject {
    * ObjectMeta describes the pod that is being evicted.
    */
   readonly metadata: NamespacedObjectMetav1;
+  /**
+   * DeleteOptions may be provided
+   */
+  readonly deleteOptions?: DeleteOptionsv1;
 
   constructor(app: K8sApp, name: string, args: Evictionv1Args) {
     super(args.metadata?.name || name);
-    this.deleteOptions = args.deleteOptions;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.deleteOptions = args.deleteOptions;
     app.addResource(this);
   }
 }

--- a/packages/core/src/models/PriorityClassv1.ts
+++ b/packages/core/src/models/PriorityClassv1.ts
@@ -3,9 +3,9 @@ import { K8sApp } from '../K8sApp.js';
 import { ApiObject } from '../ApiObject.js';
 
 export interface PriorityClassv1Args {
+  readonly metadata?: ObjectMetav1;
   readonly description?: string;
   readonly globalDefault?: boolean;
-  readonly metadata?: ObjectMetav1;
   readonly preemptionPolicy?: string;
   readonly value: number;
 }
@@ -19,14 +19,6 @@ export class PriorityClassv1 extends ApiObject {
    */
   readonly apiVersion = 'scheduling.k8s.io/v1';
   /**
-   * description is an arbitrary string that usually provides guidelines on when this priority class should be used.
-   */
-  readonly description?: string;
-  /**
-   * globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
-   */
-  readonly globalDefault?: boolean;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'PriorityClass';
@@ -34,6 +26,14 @@ export class PriorityClassv1 extends ApiObject {
    * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
    */
   readonly metadata: ObjectMetav1;
+  /**
+   * description is an arbitrary string that usually provides guidelines on when this priority class should be used.
+   */
+  readonly description?: string;
+  /**
+   * globalDefault specifies whether this PriorityClass should be considered as the default priority for pods that do not have any priority class. Only one PriorityClass can be marked as `globalDefault`. However, if more than one PriorityClasses exists with their `globalDefault` field set to true, the smallest value of such global default PriorityClasses will be used as the default priority.
+   */
+  readonly globalDefault?: boolean;
   /**
    * preemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
    */
@@ -45,10 +45,10 @@ export class PriorityClassv1 extends ApiObject {
 
   constructor(app: K8sApp, name: string, args: PriorityClassv1Args) {
     super(args.metadata?.name || name);
-    this.description = args.description;
-    this.globalDefault = args.globalDefault;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.description = args.description;
+    this.globalDefault = args.globalDefault;
     this.preemptionPolicy = args.preemptionPolicy;
     this.value = args.value;
     app.addResource(this);

--- a/packages/core/src/models/RuntimeClassv1.ts
+++ b/packages/core/src/models/RuntimeClassv1.ts
@@ -5,8 +5,8 @@ import { K8sApp } from '../K8sApp.js';
 import { ApiObject } from '../ApiObject.js';
 
 export interface RuntimeClassv1Args {
-  readonly handler: string;
   readonly metadata?: ObjectMetav1;
+  readonly handler: string;
   readonly overhead?: Overheadv1;
   readonly scheduling?: Schedulingv1;
 }
@@ -20,10 +20,6 @@ export class RuntimeClassv1 extends ApiObject {
    */
   readonly apiVersion = 'node.k8s.io/v1';
   /**
-   * handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called \"runc\" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements, and is immutable.
-   */
-  readonly handler: string;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'RuntimeClass';
@@ -31,6 +27,10 @@ export class RuntimeClassv1 extends ApiObject {
    * More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
    */
   readonly metadata: ObjectMetav1;
+  /**
+   * handler specifies the underlying runtime and configuration that the CRI implementation will use to handle pods of this class. The possible values are specific to the node & CRI configuration.  It is assumed that all handlers are available on every node, and handlers of the same name are equivalent on every node. For example, a handler called \"runc\" might specify that the runc OCI runtime (using native Linux containers) will be used to run the containers in a pod. The Handler must be lowercase, conform to the DNS Label (RFC 1123) requirements, and is immutable.
+   */
+  readonly handler: string;
   /**
    * overhead represents the resource overhead associated with running a pod for a given RuntimeClass. For more details, see  https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/
    */
@@ -42,9 +42,9 @@ export class RuntimeClassv1 extends ApiObject {
 
   constructor(app: K8sApp, name: string, args: RuntimeClassv1Args) {
     super(args.metadata?.name || name);
-    this.handler = args.handler;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.handler = args.handler;
     this.overhead = args.overhead;
     this.scheduling = args.scheduling;
     app.addResource(this);

--- a/packages/core/src/models/Secretv1.ts
+++ b/packages/core/src/models/Secretv1.ts
@@ -2,9 +2,9 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface Secretv1Args {
+  readonly metadata?: NamespacedObjectMetav1;
   readonly data?: { [key: string]: string };
   readonly immutable?: boolean;
-  readonly metadata?: NamespacedObjectMetav1;
   readonly stringData?: { [key: string]: string };
   readonly type?: string;
 }
@@ -18,14 +18,6 @@ export class Secretv1 extends NamespacedApiObject {
    */
   readonly apiVersion = 'v1';
   /**
-   * Data contains the secret data. Each key must consist of alphanumeric characters, \'-\', \'_\' or \'.\'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
-   */
-  readonly data?: { [key: string]: string };
-  /**
-   * Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
-   */
-  readonly immutable?: boolean;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'Secret';
@@ -33,6 +25,14 @@ export class Secretv1 extends NamespacedApiObject {
    * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
    */
   readonly metadata: NamespacedObjectMetav1;
+  /**
+   * Data contains the secret data. Each key must consist of alphanumeric characters, \'-\', \'_\' or \'.\'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4
+   */
+  readonly data?: { [key: string]: string };
+  /**
+   * Immutable, if set to true, ensures that data stored in the Secret cannot be updated (only object metadata can be modified). If not set to true, the field can be modified at any time. Defaulted to nil.
+   */
+  readonly immutable?: boolean;
   /**
    * stringData allows specifying non-binary secret data in string form. It is provided as a write-only input field for convenience. All keys and values are merged into the data field on write, overwriting any existing values. The stringData field is never output when reading from the API.
    */
@@ -44,10 +44,10 @@ export class Secretv1 extends NamespacedApiObject {
 
   constructor(app: K8sApp, name: string, args: Secretv1Args) {
     super(args.metadata?.name || name);
-    this.data = args.data;
-    this.immutable = args.immutable;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.data = args.data;
+    this.immutable = args.immutable;
     this.stringData = args.stringData;
     this.type = args.type;
     app.addResource(this);

--- a/packages/core/src/models/ServiceAccountv1.ts
+++ b/packages/core/src/models/ServiceAccountv1.ts
@@ -4,9 +4,9 @@ import { K8sApp } from '../K8sApp.js';
 import { NamespacedObjectMetav1, NamespacedApiObject } from '../ApiObject.js';
 
 export interface ServiceAccountv1Args {
+  readonly metadata?: NamespacedObjectMetav1;
   readonly automountServiceAccountToken?: boolean;
   readonly imagePullSecrets?: Array<LocalObjectReferencev1>;
-  readonly metadata?: NamespacedObjectMetav1;
   readonly secrets?: Array<ObjectReferencev1>;
 }
 
@@ -19,14 +19,6 @@ export class ServiceAccountv1 extends NamespacedApiObject {
    */
   readonly apiVersion = 'v1';
   /**
-   * AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
-   */
-  readonly automountServiceAccountToken?: boolean;
-  /**
-   * ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-   */
-  readonly imagePullSecrets?: Array<LocalObjectReferencev1>;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'ServiceAccount';
@@ -35,16 +27,24 @@ export class ServiceAccountv1 extends NamespacedApiObject {
    */
   readonly metadata: NamespacedObjectMetav1;
   /**
+   * AutomountServiceAccountToken indicates whether pods running as this service account should have an API token automatically mounted. Can be overridden at the pod level.
+   */
+  readonly automountServiceAccountToken?: boolean;
+  /**
+   * ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+   */
+  readonly imagePullSecrets?: Array<LocalObjectReferencev1>;
+  /**
    * Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a \"kubernetes.io/enforce-mountable-secrets\" annotation set to \"true\". The \"kubernetes.io/enforce-mountable-secrets\" annotation is deprecated since v1.32. Prefer separate namespaces to isolate access to mounted secrets. This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret
    */
   readonly secrets?: Array<ObjectReferencev1>;
 
   constructor(app: K8sApp, name: string, args: ServiceAccountv1Args) {
     super(args.metadata?.name || name);
-    this.automountServiceAccountToken = args.automountServiceAccountToken;
-    this.imagePullSecrets = args.imagePullSecrets;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.automountServiceAccountToken = args.automountServiceAccountToken;
+    this.imagePullSecrets = args.imagePullSecrets;
     this.secrets = args.secrets;
     app.addResource(this);
   }

--- a/packages/core/src/models/StorageClassv1.ts
+++ b/packages/core/src/models/StorageClassv1.ts
@@ -4,9 +4,9 @@ import { K8sApp } from '../K8sApp.js';
 import { ApiObject } from '../ApiObject.js';
 
 export interface StorageClassv1Args {
+  readonly metadata?: ObjectMetav1;
   readonly allowVolumeExpansion?: boolean;
   readonly allowedTopologies?: Array<TopologySelectorTermv1>;
-  readonly metadata?: ObjectMetav1;
   readonly mountOptions?: Array<string>;
   readonly parameters?: { [key: string]: string };
   readonly provisioner: string;
@@ -19,14 +19,6 @@ export interface StorageClassv1Args {
  */
 export class StorageClassv1 extends ApiObject {
   /**
-   * allowVolumeExpansion shows whether the storage class allow volume expand.
-   */
-  readonly allowVolumeExpansion?: boolean;
-  /**
-   * allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
-   */
-  readonly allowedTopologies?: Array<TopologySelectorTermv1>;
-  /**
    * APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
    */
   readonly apiVersion = 'storage.k8s.io/v1';
@@ -38,6 +30,14 @@ export class StorageClassv1 extends ApiObject {
    * Standard object\'s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
    */
   readonly metadata: ObjectMetav1;
+  /**
+   * allowVolumeExpansion shows whether the storage class allow volume expand.
+   */
+  readonly allowVolumeExpansion?: boolean;
+  /**
+   * allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.
+   */
+  readonly allowedTopologies?: Array<TopologySelectorTermv1>;
   /**
    * mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class. e.g. [\"ro\", \"soft\"]. Not validated - mount of the PVs will simply fail if one is invalid.
    */
@@ -61,10 +61,10 @@ export class StorageClassv1 extends ApiObject {
 
   constructor(app: K8sApp, name: string, args: StorageClassv1Args) {
     super(args.metadata?.name || name);
-    this.allowVolumeExpansion = args.allowVolumeExpansion;
-    this.allowedTopologies = args.allowedTopologies;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.allowVolumeExpansion = args.allowVolumeExpansion;
+    this.allowedTopologies = args.allowedTopologies;
     this.mountOptions = args.mountOptions;
     this.parameters = args.parameters;
     this.provisioner = args.provisioner;

--- a/packages/core/src/models/VolumeAttributesClassv1alpha1.ts
+++ b/packages/core/src/models/VolumeAttributesClassv1alpha1.ts
@@ -3,8 +3,8 @@ import { K8sApp } from '../K8sApp.js';
 import { ApiObject } from '../ApiObject.js';
 
 export interface VolumeAttributesClassv1alpha1Args {
-  readonly driverName: string;
   readonly metadata?: ObjectMetav1;
+  readonly driverName: string;
   readonly parameters?: { [key: string]: string };
 }
 
@@ -17,10 +17,6 @@ export class VolumeAttributesClassv1alpha1 extends ApiObject {
    */
   readonly apiVersion = 'storage.k8s.io/v1alpha1';
   /**
-   * Name of the CSI driver This field is immutable.
-   */
-  readonly driverName: string;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'VolumeAttributesClass';
@@ -29,15 +25,19 @@ export class VolumeAttributesClassv1alpha1 extends ApiObject {
    */
   readonly metadata: ObjectMetav1;
   /**
+   * Name of the CSI driver This field is immutable.
+   */
+  readonly driverName: string;
+  /**
    * parameters hold volume attributes defined by the CSI driver. These values are opaque to the Kubernetes and are passed directly to the CSI driver. The underlying storage provider supports changing these attributes on an existing volume, however the parameters field itself is immutable. To invoke a volume update, a new VolumeAttributesClass should be created with new parameters, and the PersistentVolumeClaim should be updated to reference the new VolumeAttributesClass.  This field is required and must contain at least one key/value pair. The keys cannot be empty, and the maximum number of parameters is 512, with a cumulative max size of 256K. If the CSI driver rejects invalid parameters, the target PersistentVolumeClaim will be set to an \"Infeasible\" state in the modifyVolumeStatus field.
    */
   readonly parameters?: { [key: string]: string };
 
   constructor(app: K8sApp, name: string, args: VolumeAttributesClassv1alpha1Args) {
     super(args.metadata?.name || name);
-    this.driverName = args.driverName;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.driverName = args.driverName;
     this.parameters = args.parameters;
     app.addResource(this);
   }

--- a/packages/core/src/models/VolumeAttributesClassv1beta1.ts
+++ b/packages/core/src/models/VolumeAttributesClassv1beta1.ts
@@ -3,8 +3,8 @@ import { K8sApp } from '../K8sApp.js';
 import { ApiObject } from '../ApiObject.js';
 
 export interface VolumeAttributesClassv1beta1Args {
-  readonly driverName: string;
   readonly metadata?: ObjectMetav1;
+  readonly driverName: string;
   readonly parameters?: { [key: string]: string };
 }
 
@@ -17,10 +17,6 @@ export class VolumeAttributesClassv1beta1 extends ApiObject {
    */
   readonly apiVersion = 'storage.k8s.io/v1beta1';
   /**
-   * Name of the CSI driver This field is immutable.
-   */
-  readonly driverName: string;
-  /**
    * Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
    */
   readonly kind = 'VolumeAttributesClass';
@@ -29,15 +25,19 @@ export class VolumeAttributesClassv1beta1 extends ApiObject {
    */
   readonly metadata: ObjectMetav1;
   /**
+   * Name of the CSI driver This field is immutable.
+   */
+  readonly driverName: string;
+  /**
    * parameters hold volume attributes defined by the CSI driver. These values are opaque to the Kubernetes and are passed directly to the CSI driver. The underlying storage provider supports changing these attributes on an existing volume, however the parameters field itself is immutable. To invoke a volume update, a new VolumeAttributesClass should be created with new parameters, and the PersistentVolumeClaim should be updated to reference the new VolumeAttributesClass.  This field is required and must contain at least one key/value pair. The keys cannot be empty, and the maximum number of parameters is 512, with a cumulative max size of 256K. If the CSI driver rejects invalid parameters, the target PersistentVolumeClaim will be set to an \"Infeasible\" state in the modifyVolumeStatus field.
    */
   readonly parameters?: { [key: string]: string };
 
   constructor(app: K8sApp, name: string, args: VolumeAttributesClassv1beta1Args) {
     super(args.metadata?.name || name);
-    this.driverName = args.driverName;
     this.metadata = args.metadata || { name };
     this.metadata.name ??= name;
+    this.driverName = args.driverName;
     this.parameters = args.parameters;
     app.addResource(this);
   }


### PR DESCRIPTION
to generate consistent yaml file