### PR TITLE
fix(cli): always define metadata.name first for CRDs

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -158,7 +158,10 @@ async function main() {
                             ],
                             statements: [
                                 'super(args.metadata?.name || name);',
-                                'this.metadata = args.metadata || { name };',
+                                'this.metadata = {',
+                                '  name: args.metadata?.name || name,',
+                                '  ...args.metadata,',
+                                '};',
                                 'this.spec = args.spec;',
                                 'app.addResource(this);',
                             ],


### PR DESCRIPTION
so the output yaml file stays consistent even if the user didn't define any metadata

followup #65 