### PR TITLE
feat: Parsing a k8sList for collections of CRDs

### DIFF
--- a/packages/cli/src/generateCRDs.ts
+++ b/packages/cli/src/generateCRDs.ts
@@ -106,8 +106,8 @@ export async function generateCRDs(crdPathOrUrl?: string, config?: K8sKonfig) {
             const url = new URL(crdPathOrUrl);
             await fetchAndParseCRDs(output[''], url.toString(), cacheHome);
         } catch (e) {
-          log(`Reading CRDs from ${pc.yellowBright(crdPathOrUrl)}`);
-          parseCRDs(output[''], fs.readFileSync(crdPathOrUrl, 'utf-8'));
+            log(`Reading CRDs from ${pc.yellowBright(crdPathOrUrl)}`);
+            parseCRDs(output[''], fs.readFileSync(crdPathOrUrl, 'utf-8'));
         }
     } else if (config) {
         for (const [pkg, urls] of Object.entries(config.crds || {})) {
@@ -119,8 +119,8 @@ export async function generateCRDs(crdPathOrUrl?: string, config?: K8sKonfig) {
                     new URL(url);
                     await fetchAndParseCRDs(output[pkg], url, cacheDir);
                 } catch (e) {
-                  log(`Reading CRDs from ${pc.yellowBright(url)}`);
-                  parseCRDs(output[pkg], fs.readFileSync(url, 'utf-8'));
+                    log(`Reading CRDs from ${pc.yellowBright(url)}`);
+                    parseCRDs(output[pkg], fs.readFileSync(url, 'utf-8'));
                 }
             }
         }

--- a/packages/cli/src/generateCRDs.ts
+++ b/packages/cli/src/generateCRDs.ts
@@ -45,7 +45,7 @@ interface K8sList {
 }
 
 function isK8sList(o: any | K8sList): o is K8sList {
-    return o && typeof(o) === "object" && "List" === o["kind"];
+    return o && typeof(o) === "object" && o["kind"] === "List";
 }
 
 interface K8sKonfig {


### PR DESCRIPTION
Added function to parse a k8sList when supplied as a file or referenced in k8skonf.

Now you can use the result of `kubectl get crds -o json > rawCrds.json` which returns a list of CRDs in a kubernetes list similar to cdk8s.